### PR TITLE
Adding SI+ES

### DIFF
--- a/loan_market_simulation/borrower.py
+++ b/loan_market_simulation/borrower.py
@@ -98,6 +98,8 @@ class Borrower:
         self.eps_end = 0.01  # Minimum value of epsilon
         self.eps_decay = 2000  # Decay rate for epsilon
         self.steps_done = 0
+
+        self.employment_stability = np.random.uniform(0.5, 1.0)
         
         # Track performance metrics
         self.avg_reward = 0
@@ -219,6 +221,9 @@ class Borrower:
                 market_state['economic_cycle'] >= -0.5  # Accept loans in moderately negative to positive conditions
             )
 
+        stability_factor = self.employment_stability * 0.2
+        decision = decision and (stability_factor > 0.7 or (affordability > 0.5 and risk_factor > 0.5))
+        
         return decision
 
     def calculate_affordability(self, loan):

--- a/loan_market_simulation/environment.py
+++ b/loan_market_simulation/environment.py
@@ -12,6 +12,8 @@ class LoanMarketEnvironment:
         self.cycle_duration = 0  # Duration of the current economic cycle
         self.max_cycle_duration = 60  # 5 years
         self.min_interest_rate = 0.03  # 3% minimum interest rate
+        self.stock_index = np.random.normal(1000, 50) 
+        self.employment_stability = np.random.uniform(0.5, 1.0)
         self.use_credit_history = use_credit_history
         self.state = self.get_state()
         self.best_values = best_values  # Store the best values for each feature
@@ -137,6 +139,8 @@ class LoanMarketEnvironment:
             'market_liquidity': self.get_market_liquidity(),
             'economic_cycle': self.economic_cycle,
             'time_step': self.time_step,
+            'stock_index': self.stock_index,
+            'employment_stability': self.employment_stability,
             'should_interest_rate_increase': 1
         }
         else:
@@ -151,6 +155,8 @@ class LoanMarketEnvironment:
                 'market_liquidity': self.get_market_liquidity(),
                 'economic_cycle': self.economic_cycle,
                 'time_step': self.time_step,
+                'stock_index': self.stock_index,
+                'employment_stability': self.employment_stability,
                 'should_interest_rate_increase': 1
             }
 

--- a/loan_market_simulation/gui.py
+++ b/loan_market_simulation/gui.py
@@ -225,7 +225,9 @@ class Visualization:
             ("Active Loans", f"{env.state['num_loans']}"),
             ("Rejected Loans", f"{env.state['num_rejected_loans']}"),
             ("Rejection Rate", f"{rejection_rate:.2%}"),
-            ("Avg Interest Rate", f"{env.state['avg_interest_rate']:.2%}")
+            ("Avg Interest Rate", f"{env.state['avg_interest_rate']:.2%}"),
+            ("Stock Index", f"{env.stock_index:.2f}"),
+            ("Employment Stability", f"{env.state['employment_stability']:.2f}"),
         ]
         
         y = 220

--- a/loan_market_simulation/lender.py
+++ b/loan_market_simulation/lender.py
@@ -162,6 +162,11 @@ class Lender:
         loan_amount = ((action_item // 10) % 5) / 4 * (self.max_loan_amount - self.min_loan_amount) + self.min_loan_amount
         term = ((action_item // 50) % 3) * 12 + 12
 
+        #Using stock indices to influence loan interest rates
+        economic_amplifier = 1 + 0.5 * state['economic_cycle']
+        stock_influence = (state['stock_index'] - 1000) * 0.0001 * economic_amplifier
+        interest_rate += stock_influence
+        
         return interest_rate, loan_amount, term
 
     def assess_loan(self, loan, borrower):


### PR DESCRIPTION
Adding Stock Index and Employment Stability. 
Comparing to the baseline model, adding stock index resulted in an increase in interest rate, while adding the employment stability increasing the number of rejected loans.
![Rej_Employ](https://github.com/user-attachments/assets/6e896fba-174b-4fb8-ba62-2e53e7007254)
![SI_IR 3 07 21 PM](https://github.com/user-attachments/assets/312700b3-1fc6-42ea-ae14-c2a10d93b516)
